### PR TITLE
fix redis client argument order

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,8 +5,8 @@ var express = require('express'),
 var app = express();
 
 var client = redis.createClient(
-  process.env.REDIS_1_PORT_6379_TCP_PORT || '127.0.01',
-  process.env.REDIS_1_PORT_6379_TCP_ADDR || 6379
+  process.env.REDIS_1_PORT_6379_TCP_PORT || 6379,
+  process.env.REDIS_1_PORT_6379_TCP_ADDR || '127.0.01'
 );
 
 app.get('/', function(req, res, next) {


### PR DESCRIPTION
shouldn't be that way?
